### PR TITLE
Created POST NFLTeams route and test using our external Tank01 API.

### DIFF
--- a/api/src/controllers/nfl-teams.controller.ts
+++ b/api/src/controllers/nfl-teams.controller.ts
@@ -3,6 +3,8 @@ import { Container } from 'typedi';
 import { CreateNFLTeamDto } from '@dtos/nfl-teams.dto';
 import { NFLTeam } from '@interfaces/nfl-teams.interface';
 import { NFLTeamService } from '@services/nfl-teams.service';
+const fetch = require('node-fetch');
+import { DB } from '@database';
 
 
 export class NFLTeamController {
@@ -20,7 +22,7 @@ export class NFLTeamController {
 
   public getNFLTeamById = async (req: Request, res: Response, next: NextFunction) : Promise<void> => {
     try {
-      const nflTeamId = Number(req.params.id);
+      const nflTeamId: number = Number(req.params.id);
       const findOneNFLTeamData: NFLTeam = await this.nflteam.findNFLTeamById(nflTeamId);
 
       res.status(200).json({ data: findOneNFLTeamData, message: 'findOne' });
@@ -28,6 +30,46 @@ export class NFLTeamController {
       next(error);
     }
   };
+  
+  public postNFLTeams = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    let nflTeams: NFLTeam[] = [];
 
+    // URL to GET NFL Teams externally.
+    const url = 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLTeams?rosters=false&schedules=false&topPerformers=false&teamStats=false';
+    const options = {
+      method: 'GET',
+      headers: {
+        'X-RapidAPI-Key': 'ca7f9abf22msh2ffe3e4ebe6d5d5p14d858jsn9109ea285446',
+        'X-RapidAPI-Host': 'tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com'
+      }
+    };
+
+    try {
+      // Get NFL teams externally.
+      const response = await fetch(url, options);
+      const result = await response.json();
+      
+      // Iterate over each element in the external result adding each team to DB.
+      try {
+        for (const element of result.body) {
+          let newNFLTeam: CreateNFLTeamDto = {
+            team_name_short: element.teamName,
+            team_name_long: element.teamCity + " " + element.teamName,
+            team_city_short: element.teamAbv,
+            team_city_long: element.teamCity,
+            team_logo: element.espnLogo1,
+          }
+          // Create team and add to response array.
+          let addNewNFLTeam: NFLTeam = await this.nflteam.createNFLTeam(newNFLTeam);
+          if (addNewNFLTeam) nflTeams.push(addNewNFLTeam);
+        }
+        res.status(200).json({ data: nflTeams, message: 'seedNFLTeams' });
+      } catch (error) {
+        next(error)
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
 }

--- a/api/src/dtos/nfl-teams.dto.ts
+++ b/api/src/dtos/nfl-teams.dto.ts
@@ -4,13 +4,13 @@ export class CreateNFLTeamDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(1)
-  @MaxLength(5)
+  @MaxLength(15)
   public team_name_short: string; 
 
   @IsString()
   @IsNotEmpty()
   @MinLength(1)
-  @MaxLength(15)
+  @MaxLength(30)
   public team_name_long: string; 
 
   @IsString()

--- a/api/src/models/nfl-teams.model.ts
+++ b/api/src/models/nfl-teams.model.ts
@@ -32,7 +32,7 @@ export default function (sequelize: Sequelize): typeof NFLTeamModel {
       team_name_long: {
         allowNull: false,
         unique: 'teamNameUnique', 
-        type: DataTypes.STRING(15)
+        type: DataTypes.STRING(30)
       }, 
       team_city_long: {
         allowNull: false,
@@ -42,7 +42,7 @@ export default function (sequelize: Sequelize): typeof NFLTeamModel {
       team_city_short: {
         allowNull: false,
         unique: 'teamCityUnique', 
-        type: DataTypes.STRING(5)
+        type: DataTypes.STRING(15)
       }, 
       team_logo: {
         allowNull: false,

--- a/api/src/routes/nfl-teams.route.ts
+++ b/api/src/routes/nfl-teams.route.ts
@@ -16,5 +16,6 @@ export class NFLTeamRoute implements Routes {
   private initializeRoutes() {
     this.router.get(`${this.path}`, this.nflteam.getNFLTeams);
     this.router.get(`${this.path}/:id(\\d+)`, this.nflteam.getNFLTeamById);
+    this.router.post(`${this.path}`, this.nflteam.postNFLTeams);
   }
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,9 +2,10 @@ import { App } from '@/app';
 import { AuthRoute } from '@routes/auth.route';
 import { UserRoute } from '@routes/users.route';
 import { ValidateEnv } from '@utils/validateEnv';
+import { NFLTeamRoute } from './routes/nfl-teams.route';
 
 ValidateEnv();
 
-const app = new App([new AuthRoute(), new UserRoute()]);
+const app = new App([new AuthRoute(), new UserRoute(), new NFLTeamRoute()]);
 
 app.listen();

--- a/api/src/services/nfl-teams.service.ts
+++ b/api/src/services/nfl-teams.service.ts
@@ -19,4 +19,12 @@ export class NFLTeamService {
     return findNFLTeam;
   }
 
+  public async createNFLTeam(nflTeam: CreateNFLTeamDto): Promise<NFLTeam> {
+    // Check if team already exists.
+    const findNFLTeam: NFLTeam = await DB.NFLTeams.findOne({ where: { team_name_long: nflTeam.team_name_long } });
+    if (findNFLTeam) throw new HttpException(409, `This nfl team ${nflTeam.team_name_long} already exists`);
+  
+    const createNFLTeam: NFLTeam = await DB.NFLTeams.create(nflTeam);
+    return createNFLTeam;
+  }
 }

--- a/api/src/test/nfl-teams.test.ts
+++ b/api/src/test/nfl-teams.test.ts
@@ -15,12 +15,30 @@ const app = new App([nflTeamsRoute]);
 const nflteams = nflTeamsRoute.nflteam.nflteam;
 const mockNFLTeamsList : NFLTeam[] = mockNFLTeams; 
 
+beforeAll(async () => {
+  await DB.NFLTeams.truncate();
+});
 
 afterAll(async () => {
   await new Promise<void>(resolve => setTimeout(() => resolve(), 500));
 });
 
 describe('Testing NFL Teams', () => {
+
+  describe('[POST] /nfl-teams', () => {
+    it('response addAll nfl-teams', async () => {
+      
+      const result = await request(app.getServer()).post(`${nflTeamsRoute.path}`);
+    
+      expect(result.status).toEqual(200);
+      expect(result.body.data[0].team_city_long).toEqual("Arizona");
+      expect(result.body.data[31].team_city_short).toEqual("WSH");
+      expect(result.body.data[25].team_name_short).toEqual("Steelers");
+      expect(result.body.data[21].team_name_long).toEqual("New England Patriots");
+      expect(result.body.data[17].team_logo).toEqual("https://a.espncdn.com/combiner/i?img=/i/teamlogos/nfl/500/lac.png");
+      expect(result.body.data.length).toEqual(32);
+    }); 
+  });
 
   describe('[GET] /nfl-teams', () => {
     it('response findAll nfl-teams', async () => {
@@ -95,7 +113,6 @@ describe('Testing NFL Teams', () => {
     });
 
   });
-
-
-
+  
+  
 });


### PR DESCRIPTION
POST NFLTeams
- route
- controller
- service
- test

Pulls Teams from external API - https://rapidapi.com/tank01/api/tank01-nfl-live-in-game-real-time-statistics-nfl

Issues - #49 #50 