### PR TITLE
External get nfl players

### DIFF
--- a/api/src/controllers/nfl-players.controller.ts
+++ b/api/src/controllers/nfl-players.controller.ts
@@ -2,6 +2,8 @@ import { NextFunction, Request, Response } from 'express';
 import { Container } from 'typedi';
 import { NFLPlayerService } from '@/services/nfl-players.service';
 import { NFLPlayer } from '@/interfaces/nfl-players.interface';
+import { NFLPlayerDTO } from '@/dtos/nfl-players.dto';
+const fetch = require('node-fetch');
 
 
 export class NFLPlayerController {
@@ -25,6 +27,47 @@ export class NFLPlayerController {
       res.status(200).json({ data: findOneNFLPlayerData, message: 'findOne' });
     } catch (error) {
       next(error);
+    }
+  };
+
+  // This method only gets the players with a projection that way we dont have 3000 players in our DB just the relavant ones.
+  public postNFLPlayers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    let nflPlayers: NFLPlayer[] = [];
+
+    // URL to GET NFL Players externally.
+    const url = 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLProjections?week=12&twoPointConversions=2&passYards=.04&passAttempts=-.5&passTD=4&passCompletions=1&passInterceptions=-2&pointsPerReception=1&carries=.2&rushYards=.1&rushTD=6&fumbles=-2&receivingYards=.1&receivingTD=6&targets=.1';
+    const options = {
+      method: 'GET',
+      headers: {
+        'X-RapidAPI-Key': 'ca7f9abf22msh2ffe3e4ebe6d5d5p14d858jsn9109ea285446',
+        'X-RapidAPI-Host': 'tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com'
+      }
+    };
+
+    try {
+      // Get NFL Players externally.
+      const response = await fetch(url, options);
+      const result = await response.json();
+
+      // Iterate over each element in the external result adding each Player to DB.
+      try {
+        for (const element of result.body) {
+          let newNFLPlayer: NFLPlayerDTO = {
+            player_name: element.player_name,
+            teamId: element.teamId,
+            position: element.position,
+            player_portrait: element.player_portrait,
+          }
+          // Create Player and add to response array.
+          let addNewNFLPlayer: NFLPlayer = await this.nflPlayer.createNFLPlayer(newNFLPlayer);
+          if (addNewNFLPlayer) nflPlayers.push(addNewNFLPlayer);
+        }
+        res.status(200).json({ data: nflPlayers, message: 'seedNFLPlayers' });
+      } catch (error) {
+        next(error)
+      }
+    } catch (error) {
+      console.error(error);
     }
   };
 }

--- a/api/src/controllers/nfl-players.controller.ts
+++ b/api/src/controllers/nfl-players.controller.ts
@@ -60,12 +60,11 @@ export class NFLPlayerController {
           }
           // Some players dont have portraits.
           validPlayer = !(!newNFLPlayer.player_portrait);
+          if (!validPlayer) newNFLPlayer.player_portrait = "https://www.gravatar.com/avatar/?d=mp";
 
           // Create Player and add to response array.
-          if (validPlayer) {
-            let addNewNFLPlayer: NFLPlayer = await this.nflPlayer.createNFLPlayer(newNFLPlayer);
-            if (addNewNFLPlayer) nflPlayers.push(addNewNFLPlayer);
-          }
+          let addNewNFLPlayer: NFLPlayer = await this.nflPlayer.createNFLPlayer(newNFLPlayer);
+          if (addNewNFLPlayer) nflPlayers.push(addNewNFLPlayer);
         }
         res.status(200).json({ data: nflPlayers, message: 'seedNFLPlayers' });
       } catch (error) {

--- a/api/src/controllers/nfl-players.controller.ts
+++ b/api/src/controllers/nfl-players.controller.ts
@@ -30,19 +30,19 @@ export class NFLPlayerController {
     }
   };
 
-  // This method only gets the players with a projection that way we dont have 3000 players in our DB just the relavant ones.
   public postNFLPlayers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     let nflPlayers: NFLPlayer[] = [];
+    let validPlayer: boolean = true;
 
     // URL to GET NFL Players externally.
-    const url = 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLProjections?week=12&twoPointConversions=2&passYards=.04&passAttempts=-.5&passTD=4&passCompletions=1&passInterceptions=-2&pointsPerReception=1&carries=.2&rushYards=.1&rushTD=6&fumbles=-2&receivingYards=.1&receivingTD=6&targets=.1';
+    const url = 'https://tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com/getNFLPlayerList';
     const options = {
       method: 'GET',
       headers: {
         'X-RapidAPI-Key': 'ca7f9abf22msh2ffe3e4ebe6d5d5p14d858jsn9109ea285446',
         'X-RapidAPI-Host': 'tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com'
       }
-    };
+    }
 
     try {
       // Get NFL Players externally.
@@ -53,14 +53,19 @@ export class NFLPlayerController {
       try {
         for (const element of result.body) {
           let newNFLPlayer: NFLPlayerDTO = {
-            player_name: element.player_name,
-            teamId: element.teamId,
-            position: element.position,
-            player_portrait: element.player_portrait,
+            player_name: element.espnName,
+            teamId: parseInt(element.teamID),
+            position: element.pos,
+            player_portrait: element.espnHeadshot,
           }
+          // Some players dont have portraits.
+          validPlayer = !(!newNFLPlayer.player_portrait);
+
           // Create Player and add to response array.
-          let addNewNFLPlayer: NFLPlayer = await this.nflPlayer.createNFLPlayer(newNFLPlayer);
-          if (addNewNFLPlayer) nflPlayers.push(addNewNFLPlayer);
+          if (validPlayer) {
+            let addNewNFLPlayer: NFLPlayer = await this.nflPlayer.createNFLPlayer(newNFLPlayer);
+            if (addNewNFLPlayer) nflPlayers.push(addNewNFLPlayer);
+          }
         }
         res.status(200).json({ data: nflPlayers, message: 'seedNFLPlayers' });
       } catch (error) {

--- a/api/src/models/nfl-players.model.ts
+++ b/api/src/models/nfl-players.model.ts
@@ -30,10 +30,12 @@ export default function (sequelize: Sequelize): typeof NFLPLayerModel {
       }, 
       teamId: {
         allowNull: true,
+        unique: 'uniquePlayer',
         type: DataTypes.INTEGER,
       }, 
       position: {
         allowNull: false,
+        unique: 'uniquePlayer',
         type: DataTypes.STRING(15)
       },
       player_portrait: {

--- a/api/src/routes/nfl-players.route.ts
+++ b/api/src/routes/nfl-players.route.ts
@@ -14,5 +14,6 @@ export class NFLPlayerRoute implements Routes {
   private initializeRoutes() {
     this.router.get(`${this.path}`, this.nflPlayer.getNFLPlayers);
     this.router.get(`${this.path}/:id(\\d+)`, this.nflPlayer.getNFLPlayerById);
+    this.router.post(`${this.path}`, this.nflPlayer.postNFLPlayers);
   }
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,9 +2,10 @@ import { App } from '@/app';
 import { AuthRoute } from '@routes/auth.route';
 import { UserRoute } from '@routes/users.route';
 import { ValidateEnv } from '@utils/validateEnv';
+import { NFLPlayerRoute } from './routes/nfl-players.route';
 
 ValidateEnv();
 
-const app = new App([new AuthRoute(), new UserRoute()]);
+const app = new App([new AuthRoute(), new UserRoute(), new NFLPlayerRoute()]);
 
 app.listen();

--- a/api/src/services/nfl-players.service.ts
+++ b/api/src/services/nfl-players.service.ts
@@ -19,7 +19,7 @@ export class NFLPlayerService {
   }
 
   public async createNFLPlayer(nflPlayer: NFLPlayerDTO): Promise<NFLPlayer> {
-    // Check if team already exists.
+    // Check if player already exists. (portraits are unique)
     const findNFLPlayer: NFLPlayer = await DB.NFLPlayers.findOne({ where: { player_name: nflPlayer.player_name, player_portrait: nflPlayer.player_portrait } });
     if (findNFLPlayer) throw new HttpException(409, `This nfl player ${nflPlayer.player_name} already exists`);
 

--- a/api/src/services/nfl-players.service.ts
+++ b/api/src/services/nfl-players.service.ts
@@ -20,7 +20,10 @@ export class NFLPlayerService {
 
   public async createNFLPlayer(nflPlayer: NFLPlayerDTO): Promise<NFLPlayer> {
     // Check if player already exists. (portraits are unique)
-    const findNFLPlayer: NFLPlayer = await DB.NFLPlayers.findOne({ where: { player_name: nflPlayer.player_name, player_portrait: nflPlayer.player_portrait } });
+    const findNFLPlayer: NFLPlayer = await DB.NFLPlayers.findOne({ where: { player_name: nflPlayer.player_name, 
+                                                                            player_portrait: nflPlayer.player_portrait,
+                                                                            position: nflPlayer.position,
+                                                                            teamId: nflPlayer.teamId } });
     if (findNFLPlayer) throw new HttpException(409, `This nfl player ${nflPlayer.player_name} already exists`);
 
     const createNFLPlayer: NFLPlayer = await DB.NFLPlayers.create(nflPlayer);

--- a/api/src/services/nfl-players.service.ts
+++ b/api/src/services/nfl-players.service.ts
@@ -2,6 +2,7 @@ import { Service } from 'typedi';
 import { DB } from '@database';
 import { HttpException } from '@/exceptions/httpException';
 import { NFLPlayer } from '@/interfaces/nfl-players.interface';
+import { NFLPlayerDTO } from '@/dtos/nfl-players.dto';
 
 @Service()
 export class NFLPlayerService {
@@ -15,5 +16,14 @@ export class NFLPlayerService {
     if (!findNFLPlayer) throw new HttpException(409, "NFL Player doesn't exist");
 
     return findNFLPlayer;
+  }
+
+  public async createNFLPlayer(nflPlayer: NFLPlayerDTO): Promise<NFLPlayer> {
+    // Check if team already exists.
+    const findNFLPlayer: NFLPlayer = await DB.NFLPlayers.findOne({ where: { player_name: nflPlayer.player_name, player_portrait: nflPlayer.player_portrait } });
+    if (findNFLPlayer) throw new HttpException(409, `This nfl player ${nflPlayer.player_name} already exists`);
+
+    const createNFLPlayer: NFLPlayer = await DB.NFLPlayers.create(nflPlayer);
+    return createNFLPlayer;
   }
 }

--- a/api/src/test/nfl-players.test.ts
+++ b/api/src/test/nfl-players.test.ts
@@ -62,6 +62,19 @@ afterAll(async () => {
 });
 
 describe("Testing NFL Players", () => {
+
+  describe('[POST] /nfl-players', () => {
+    it('response addAll nfl-players', async () => {
+
+      const result = await request(app.getServer()).post(`${nflPlayersRoute.path}`);
+
+      expect(result.status).toEqual(200);
+      expect(result.body.data.length).toBeGreaterThanOrEqual(2000);
+    
+    // Set timeout to 20 seconds to give test time to add every player.
+    }, 20000); 
+  });
+
   describe('[GET] /nfl-players', () => {
     it('response findAll nfl-players', async () => {
       // Call our GET NFL players endpoint
@@ -69,7 +82,6 @@ describe("Testing NFL Players", () => {
       
       // Check for good status and all five players in response
       expect(result.status).toEqual(200);
-      expect(result.body.data.length).toEqual(5);
       // Randomly check 1 value from each player in the response
       expect(result.body.data[0].position).toEqual(player1.position);
       expect(result.body.data[1].player_portrait).toEqual(player2.player_portrait);
@@ -104,7 +116,7 @@ describe("Testing NFL Players", () => {
 
     it('response findOne nfl-player - exception', async () => {
       const mockNFLPlayer : NFLPlayer = {
-        id: 6,
+        id: 6000,
         player_name: "Player 6",
         teamId: 6,
         position: "Defense",


### PR DESCRIPTION
POST NFLPlayers

- route
- controller
- service
- test
Pulls Players from external API - https://rapidapi.com/tank01/api/tank01-nfl-live-in-game-real-time-statistics-nfl

Issues - #50 