### PR TITLE
(UI) Match Details Screen

### DIFF
--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": false
 }

--- a/client/app/components/MatchScorePreview.tsx
+++ b/client/app/components/MatchScorePreview.tsx
@@ -18,16 +18,20 @@ interface MatchScorePreviewProps {
 }
 
 export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetails, navigation, isNavigtionActive }) => {
-
-
   /**
    * Function to navigate to the corresponding match's details page. 
+   * Also, it passes the matchDetails to the Match Details screen in 
+   * the form of the variable 'currentMatchState'. 
    * 
    * TODO: implement UX to go to that match's specific page. 
+   * TODO: Currently using React Navigation to pass in the specific 
+   *       match's info. In future, transition to using MobX-State-Tree
    */
   const handleMatchDetailPress = () => {
     if (isNavigtionActive && navigation) {
-      navigation.navigate("MatchDetails"); 
+      navigation.navigate("MatchDetails", {
+        currentMatchState: matchDetails
+      }); 
     }
   }
 

--- a/client/app/components/MatchScorePreview.tsx
+++ b/client/app/components/MatchScorePreview.tsx
@@ -1,6 +1,6 @@
 import { Pressable, Image, View, Text, ViewStyle, TextStyle, ImageStyle } from "react-native";
 import { MatchScorePreviewType } from "./MatchScorePreviewTempData/MatchScorePreviewData";
-import { typography } from "app/theme";
+import { colors, typography } from "app/theme";
 import { AppStackParamList } from "app/navigators/AppNavigator";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
@@ -63,7 +63,8 @@ const $mainContainer: ViewStyle = {
   height: 120,
   width: 330,
   maxHeight: 120,
-  backgroundColor: "#1D1D1D",
+  // backgroundColor: "#1D1D1D",
+  backgroundColor: colors.secondaryBackground,
   borderRadius: 20,
   flex: 1,
   flexDirection: "row",

--- a/client/app/components/MatchScorePreview.tsx
+++ b/client/app/components/MatchScorePreview.tsx
@@ -14,10 +14,10 @@ type MatchListNavigationProp = NativeStackNavigationProp<
 interface MatchScorePreviewProps {
   matchDetails: MatchScorePreviewType;
   navigation?: MatchListNavigationProp;
-  isNavigtionActive: boolean; 
+  isNavigationActive: boolean; 
 }
 
-export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetails, navigation, isNavigtionActive }) => {
+export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetails, navigation, isNavigationActive }) => {
   /**
    * Function to navigate to the corresponding match's details page. 
    * Also, it passes the matchDetails to the Match Details screen in 
@@ -28,7 +28,7 @@ export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetai
    *       match's info. In future, transition to using MobX-State-Tree
    */
   const handleMatchDetailPress = () => {
-    if (isNavigtionActive && navigation) {
+    if (isNavigationActive && navigation) {
       navigation.navigate("MatchDetails", {
         currentMatchState: matchDetails
       }); 
@@ -37,7 +37,7 @@ export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetai
 
   {/* Each component gets its data from the matchDetails prop */}
   return (
-    <Pressable style={$mainContainer} disabled={!isNavigtionActive} onPress={handleMatchDetailPress}>
+    <Pressable style={$mainContainer} disabled={!isNavigationActive} onPress={handleMatchDetailPress}>
       <Image style={$teamLogo} source={matchDetails.team1ImageSource} resizeMode="contain"/>
       <View style={[$detailsContainer, {paddingRight: 5, marginLeft: -10}]}>
         {/* Need to change so text overflows */}

--- a/client/app/components/MatchScorePreview.tsx
+++ b/client/app/components/MatchScorePreview.tsx
@@ -1,16 +1,39 @@
 import { Pressable, Image, View, Text, ViewStyle, TextStyle, ImageStyle } from "react-native";
 import { MatchScorePreviewType } from "./MatchScorePreviewTempData/MatchScorePreviewData";
 import { typography } from "app/theme";
+import { AppStackParamList } from "app/navigators/AppNavigator";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+
+type MatchListNavigationProp = NativeStackNavigationProp<
+  AppStackParamList,
+  'MatchList'
+>
 
 // Mock interface this way we save time when linking up client and api.
 interface MatchScorePreviewProps {
   matchDetails: MatchScorePreviewType;
+  navigation?: MatchListNavigationProp;
+  isNavigtionActive: boolean; 
 }
 
-export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetails }) => {
+export const MatchScorePreview: React.FC<MatchScorePreviewProps> = ({ matchDetails, navigation, isNavigtionActive }) => {
+
+
+  /**
+   * Function to navigate to the corresponding match's details page. 
+   * 
+   * TODO: implement UX to go to that match's specific page. 
+   */
+  const handleMatchDetailPress = () => {
+    if (isNavigtionActive && navigation) {
+      navigation.navigate("MatchDetails"); 
+    }
+  }
+
   {/* Each component gets its data from the matchDetails prop */}
   return (
-    <Pressable style={$mainContainer}>
+    <Pressable style={$mainContainer} disabled={!isNavigtionActive} onPress={handleMatchDetailPress}>
       <Image style={$teamLogo} source={matchDetails.team1ImageSource} resizeMode="contain"/>
       <View style={[$detailsContainer, {paddingRight: 5, marginLeft: -10}]}>
         {/* Need to change so text overflows */}

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { VStack, HStack, Text, Button, ButtonText, View, EditIcon, Avatar, AvatarBadge, AvatarFallbackText, AvatarImage, Icon, ButtonIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Heading } from "@gluestack-ui/themed";
+import { VStack, HStack, Text, Button, ButtonText, View, EditIcon, Avatar, AvatarBadge, AvatarFallbackText, AvatarImage, Icon, ButtonIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Heading, Box } from "@gluestack-ui/themed";
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native';
 import { colors, typography} from "app/theme"
 import { AppStackParamList } from 'app/navigators/AppNavigator';
@@ -13,14 +13,29 @@ type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
 interface PlayerHeadToHeadProps {
   navigation: MatchDetailsScreenNavigationProp;
   position: string; 
-  challengerTeamPlayer: string; 
-  participantTeamPlayer: string; 
-
+  player1: string; 
+  player2: string;
+  player1TeamShort: string; 
+  player2TeamShort: string;
+  player1Points: number;
+  player2Points: number;
 }
 
+type PositionColors = {
+  [key: string]: string;
+};
+
+const positionColors: PositionColors = {
+  "QB": "#FFC107", 
+  "RB": "#4CAF50", 
+  "WR": "#2196F3", 
+  "TE": "#9C27B0", 
+  "K": "#FF9800", 
+  "DST": "#F44336"
+}
 
 /**
- * 
+ * Component that displays a head to head comparison of two NFL players of the same position. 
  * 
  * @param props 
  * @returns 
@@ -36,16 +51,119 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
   }
 
   return (
-    <View>
+    <View
+      flexDirection={"row"}
+      width={"100%"}
+      height={49}
+      backgroundColor={colors.secondaryBackground}
+
+      alignItems={"center"}
+      justifyContent={"space-around"}
+      borderRadius={5}
+      // boxShadow={"0px 4px 4px rgba(0, 0, 0, 0.25)"}
+      paddingLeft={10}
+      paddingRight={10}
+    >
+
       <View
-        display='flex'
-        flexDirection='row'
-        alignItems='center'
-        justifyContent='center'
-        position='relative'
+        flexDirection={"column"}
+        alignItems={"flex-start"}
+        justifyContent={"center"}
       >
+        <Text
+          color={colors.text}
+          textAlign='center'
+          fontFamily={typography.fonts.poppins.semiBold}
+          fontSize={14}
+        >
+          {props.player1}
+        </Text>
+        <Text
+          color={colors.text}
+          textAlign='center'
+          fontFamily={typography.fonts.poppins.normal}
+          fontSize={10}
+        >
+          {props.player1TeamShort} • {props.position}
+        </Text>
       </View>
 
+      <Text
+        color={colors.text}
+        textAlign='center'
+        fontFamily={typography.fonts.poppins.semiBold}
+        fontSize={17}
+      >
+        {props.player1Points}
+      </Text>
+
+      <Box
+        bg={positionColors[props.position]}
+        h={45}
+        w={45}
+        borderRadius={10}
+        display="flex"
+        justifyContent="center" 
+        alignItems="center" 
+      >
+        <Text
+          color={colors.textBlack}
+          textAlign='center'
+          fontFamily={typography.fonts.poppins.semiBold}
+          fontSize={20}
+        >
+          {props.position}
+        </Text>
+      </Box>
+
+      <Text
+        color={colors.text}
+        textAlign='center'
+        fontFamily={typography.fonts.poppins.semiBold}
+        fontSize={17}
+      >
+        {props.player2Points}
+      </Text>
+
+      <View
+        flexDirection={"column"}
+        alignItems={"flex-end"}
+        justifyContent={"center"}
+      >
+        <Text
+          color={colors.text}
+          textAlign='center'
+          fontFamily={typography.fonts.poppins.semiBold}
+          fontSize={14}
+        >
+          {props.player1}
+        </Text>
+        <Text
+          color={colors.text}
+          textAlign='center'
+          fontFamily={typography.fonts.poppins.normal}
+          fontSize={10}
+        >
+          {props.player1TeamShort} • {props.position}
+        </Text>
+      </View>
+
+
     </View>
+    
+
+    // <View 
+    //   flex={1}
+    //   flexDirection={"row"}
+    //   // width={"100%"}
+    //   width={20}
+    //   height={20}
+    //   backgroundColor={colors.secondaryBackground}
+
+    // >
+    //   {/* <Text>
+    //     Hello
+    //   </Text> */}
+    // </View>
   );
 };

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
+import { Dimensions } from 'react-native';
 import { VStack, HStack, Text, Button, ButtonText, View, EditIcon, Avatar, AvatarBadge, AvatarFallbackText, AvatarImage, Icon, ButtonIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Heading, Box } from "@gluestack-ui/themed";
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native';
 import { colors, typography} from "app/theme"
 import { AppStackParamList } from 'app/navigators/AppNavigator';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+const WINDOW_WIDTH = Dimensions.get('window').width;
 
 type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
   AppStackParamList,
@@ -15,6 +18,8 @@ interface PlayerHeadToHeadProps {
   position: string; 
   player1Name: string; 
   player2Name: string;
+  player1NameShort: string;
+  player2NameShort: string;
   player1TeamCityShort: string; 
   player2TeamCityShort: string;
   player1Points: number;
@@ -28,12 +33,12 @@ type PositionColors = {
 };
 
 const positionColors: PositionColors = {
-  "QB": "#FFC107", 
-  "RB": "#4CAF50", 
-  "WR": "#2196F3", 
-  "TE": "#9C27B0", 
-  "K": "#FF9800", 
-  "DST": "#F44336"
+  "qb": "#FFC107", 
+  "rb": "#4CAF50", 
+  "wr": "#2196F3", 
+  "te": "#9C27B0", 
+  "k": "#FF9800", 
+  "dst": "#F44336"
 }
 
 /**
@@ -43,14 +48,6 @@ const positionColors: PositionColors = {
  * @returns 
  */
 export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
-  const [avatar, setAvatar] = useState<string>(""); 
-
-
-  /**
-   * Function to select an avatar and close the modal. 
-   */
-  const handleSelectAvatar = (avatarLink: string): void => {
-  }
 
   return (
     <View
@@ -61,10 +58,13 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
 
       alignItems={"center"}
       justifyContent={"space-around"}
+      position={"relative"}
       borderRadius={5}
       // boxShadow={"0px 4px 4px rgba(0, 0, 0, 0.25)"}
       paddingLeft={10}
       paddingRight={10}
+      marginTop={5}
+      marginBottom={5}
     >
 
 {/**---------------------------------------------------------------- */}
@@ -72,7 +72,12 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
       <View
         flexDirection={"column"}
         alignItems={"flex-start"}
-        justifyContent={"center"}
+
+        position="absolute" 
+        // Must use left instead of right margin
+        // Because want component's LHS to alwasy line up
+        left={8} 
+
       >
         <Text
           color={colors.text}
@@ -80,7 +85,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={14}
         >
-          {props.player1Name}
+          {props.player1NameShort}
         </Text>
         <Text
           color={colors.text}
@@ -88,7 +93,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.normal}
           fontSize={10}
         >
-          {props.player1TeamCityShort} • {props.position}
+          {props.player1TeamCityShort} • {props.position.toUpperCase()}
         </Text>
       </View>
 
@@ -99,6 +104,13 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
         textAlign='center'
         fontFamily={typography.fonts.poppins.semiBold}
         fontSize={17}
+        marginHorizontal={8}
+
+        position="absolute" 
+        // Must use right instead of left margin
+        // Because want this score's right hand side to always be 72.5 pixels from the center
+        right={WINDOW_WIDTH / 2 - 22.5 + 50} 
+
       >
         {props.player1Points}
       </Text>
@@ -110,6 +122,11 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
         h={45}
         w={45}
         borderRadius={10}
+
+        position="absolute" // Set the position component's position to absolute
+        left={WINDOW_WIDTH / 2 - 22.5} // Calculate the left margin to center the position component
+        right={WINDOW_WIDTH / 2 - 22.5} // Calculate the right margin to center the position component    
+
         display="flex"
         justifyContent="center" 
         alignItems="center" 
@@ -120,7 +137,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={20}
         >
-          {props.position}
+          {props.position.toUpperCase()}
         </Text>
       </Box>
 
@@ -131,6 +148,13 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
         textAlign='center'
         fontFamily={typography.fonts.poppins.semiBold}
         fontSize={17}
+        marginHorizontal={8}
+
+        position="absolute" 
+        // Must use left instead of right margin
+        // Because want this score's left hand side to always be 72.5 pixels from the center
+        left={WINDOW_WIDTH / 2 - 22.5 + 50} 
+
       >
         {props.player2Points}
       </Text>
@@ -140,7 +164,12 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
       <View
         flexDirection={"column"}
         alignItems={"flex-end"}
-        justifyContent={"center"}
+
+        position="absolute" 
+        // Must use right instead of left margin
+        // Because want component's RHS to alwasy line up
+        right={8} 
+
       >
         <Text
           color={colors.text}
@@ -148,7 +177,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={14}
         >
-          {props.player2Name}
+          {props.player2NameShort}
         </Text>
         <Text
           color={colors.text}
@@ -156,7 +185,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.normal}
           fontSize={10}
         >
-          {props.player2TeamCityShort} • {props.position}
+          {props.player2TeamCityShort} • {props.position.toUpperCase()}
         </Text>
       </View>
 
@@ -164,19 +193,5 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
 
     </View>
     
-
-    // <View 
-    //   flex={1}
-    //   flexDirection={"row"}
-    //   // width={"100%"}
-    //   width={20}
-    //   height={20}
-    //   backgroundColor={colors.secondaryBackground}
-
-    // >
-    //   {/* <Text>
-    //     Hello
-    //   </Text> */}
-    // </View>
   );
 };

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -13,12 +13,14 @@ type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
 interface PlayerHeadToHeadProps {
   navigation: MatchDetailsScreenNavigationProp;
   position: string; 
-  player1: string; 
-  player2: string;
-  player1TeamShort: string; 
-  player2TeamShort: string;
+  player1Name: string; 
+  player2Name: string;
+  player1TeamCityShort: string; 
+  player2TeamCityShort: string;
   player1Points: number;
   player2Points: number;
+  player1Portrait: string; 
+  player2Portrait: string; 
 }
 
 type PositionColors = {
@@ -65,6 +67,8 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
       paddingRight={10}
     >
 
+{/**---------------------------------------------------------------- */}
+
       <View
         flexDirection={"column"}
         alignItems={"flex-start"}
@@ -76,7 +80,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={14}
         >
-          {props.player1}
+          {props.player1Name}
         </Text>
         <Text
           color={colors.text}
@@ -84,9 +88,11 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.normal}
           fontSize={10}
         >
-          {props.player1TeamShort} • {props.position}
+          {props.player1TeamCityShort} • {props.position}
         </Text>
       </View>
+
+{/**---------------------------------------------------------------- */}
 
       <Text
         color={colors.text}
@@ -96,6 +102,8 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
       >
         {props.player1Points}
       </Text>
+
+{/**---------------------------------------------------------------- */}
 
       <Box
         bg={positionColors[props.position]}
@@ -116,6 +124,8 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
         </Text>
       </Box>
 
+{/**---------------------------------------------------------------- */}
+
       <Text
         color={colors.text}
         textAlign='center'
@@ -124,6 +134,8 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
       >
         {props.player2Points}
       </Text>
+
+{/**---------------------------------------------------------------- */}
 
       <View
         flexDirection={"column"}
@@ -136,7 +148,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={14}
         >
-          {props.player1}
+          {props.player2Name}
         </Text>
         <Text
           color={colors.text}
@@ -144,10 +156,11 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
           fontFamily={typography.fonts.poppins.normal}
           fontSize={10}
         >
-          {props.player1TeamShort} • {props.position}
+          {props.player2TeamCityShort} • {props.position}
         </Text>
       </View>
 
+{/**---------------------------------------------------------------- */}
 
     </View>
     

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { VStack, HStack, Text, Button, ButtonText, View, EditIcon, Avatar, AvatarBadge, AvatarFallbackText, AvatarImage, Icon, ButtonIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Heading } from "@gluestack-ui/themed";
+import { EyeIcon, EyeOffIcon } from 'lucide-react-native';
+import { colors, typography} from "app/theme"
+import { AppStackParamList } from 'app/navigators/AppNavigator';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
+  AppStackParamList,
+  'MatchDetails'
+>
+
+interface PlayerHeadToHeadProps {
+  navigation: MatchDetailsScreenNavigationProp;
+  position: string; 
+  challengerTeamPlayer: string; 
+  participantTeamPlayer: string; 
+
+}
+
+
+/**
+ * 
+ * 
+ * @param props 
+ * @returns 
+ */
+export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
+  const [avatar, setAvatar] = useState<string>(""); 
+
+
+  /**
+   * Function to select an avatar and close the modal. 
+   */
+  const handleSelectAvatar = (avatarLink: string): void => {
+  }
+
+  return (
+    <View>
+      <View
+        display='flex'
+        flexDirection='row'
+        alignItems='center'
+        justifyContent='center'
+        position='relative'
+      >
+      </View>
+
+    </View>
+  );
+};

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -140,13 +140,13 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
 
         display="flex"
         justifyContent="center" 
-        alignItems="center" 
       >
         <Text
           color={colors.textBlack}
           textAlign='center'
           fontFamily={typography.fonts.poppins.semiBold}
           fontSize={20}
+          lineHeight={30}
         >
           {props.position.toUpperCase()}
         </Text>

--- a/client/app/components/PlayerHeadToHead.tsx
+++ b/client/app/components/PlayerHeadToHead.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Dimensions } from 'react-native';
 import { VStack, HStack, Text, Button, ButtonText, View, EditIcon, Avatar, AvatarBadge, AvatarFallbackText, AvatarImage, Icon, ButtonIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Heading, Box } from "@gluestack-ui/themed";
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native';
@@ -28,19 +28,6 @@ interface PlayerHeadToHeadProps {
   player2Portrait: string; 
 }
 
-type PositionColors = {
-  [key: string]: string;
-};
-
-const positionColors: PositionColors = {
-  "qb": "#FFC107", 
-  "rb": "#4CAF50", 
-  "wr": "#2196F3", 
-  "te": "#9C27B0", 
-  "k": "#FF9800", 
-  "dst": "#F44336"
-}
-
 /**
  * Component that displays a head to head comparison of two NFL players of the same position. 
  * 
@@ -48,6 +35,30 @@ const positionColors: PositionColors = {
  * @returns 
  */
 export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
+  const [positionBgColor, setPositionBgColor] = React.useState<string>("");
+
+  useEffect(() => {
+    switch(props.position) {
+      case "qb":
+        setPositionBgColor(colors.qbBackground);
+        break;
+      case "rb":
+        setPositionBgColor(colors.rbBackground);
+        break;
+      case "wr":
+        setPositionBgColor(colors.wrBackground);
+        break; 
+      case "te":
+        setPositionBgColor(colors.teBackground);
+        break;
+      case "k":
+        setPositionBgColor(colors.kBackground);
+        break;
+      case "dst":
+        setPositionBgColor(colors.dstBackground);
+        break;
+    }
+  }, []);
 
   return (
     <View
@@ -118,7 +129,7 @@ export function PlayerHeadToHead(props: PlayerHeadToHeadProps){
 {/**---------------------------------------------------------------- */}
 
       <Box
-        bg={positionColors[props.position]}
+        bg={positionBgColor}
         h={45}
         w={45}
         borderRadius={10}

--- a/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
+++ b/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
@@ -6,6 +6,231 @@ export type NFLPlayerModel = {
   player_portrait: string, 
 }
 
+export type PlayerInfo = {
+  id: number;
+  player_name: string;
+  teamId: number;
+  position: string;
+  player_portrait: string;
+  player_team_name_short: string;
+  player_team_name_long: string;
+  player_team_city_short: string;
+  player_team_city_long: string;
+  player_points: number;
+}
+
+export type FantasyTeam = {
+  qb: PlayerInfo;
+  rb1: PlayerInfo;
+  rb2: PlayerInfo;
+  wr1: PlayerInfo;
+  wr2: PlayerInfo;
+  te: PlayerInfo;
+  dst: PlayerInfo;
+  k: PlayerInfo;
+};
+
+export type FantasyTeamKey = keyof FantasyTeam;
+
+// Create an object of a team of players with 1 qb, 2 rb's, 2 wr's, 1 te, 1 dst, and 1 k
+export const USER1_TEAM : FantasyTeam = {
+  qb: {
+    id: 1, 
+    player_name: "Josh Allen", 
+    teamId: 4, 
+    position: 'qb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3918298.png', 
+    player_team_name_short: 'Bills',
+    player_team_name_long: 'Buffalo Bills',
+    player_team_city_short: 'BUF',
+    player_team_city_long: 'Buffalo',
+    player_points: 25.2
+  }, 
+  rb1: {
+    id: 1, 
+    player_name: "Christian McCaffrey", 
+    teamId: 27, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3117251.png', 
+    player_team_name_short: 'Panthers',
+    player_team_name_long: 'Carolina Panthers',
+    player_team_city_short: 'CAR',
+    player_team_city_long: 'Carolina',
+    player_points: 22.3
+  },
+  rb2: {
+    id: 1, 
+    player_name: "Kyren Williams", 
+    teamId: 29, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
+    player_team_name_short: 'Rams',
+    player_team_name_long: 'Los Angeles Rams',
+    player_team_city_short: 'LAR',
+    player_team_city_long: 'Los Angeles',
+    player_points: 18.7
+  },
+  wr1: {
+    id: 1, 
+    player_name: "Tyreek Hill", 
+    teamId: 17, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3116406.png', 
+    player_team_name_short: 'Dolphins',
+    player_team_name_long: 'Miami Dolphins',
+    player_team_city_short: 'MIA',
+    player_team_city_long: 'Miami',
+    player_points: 17.3
+  },
+  wr2: {
+    id: 1, 
+    player_name: "CeeDee Lamb", 
+    teamId: 9, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241389.png', 
+    player_team_name_short: 'Cowboys',
+    player_team_name_long: 'Dallas Cowboys',
+    player_team_city_short: 'DAL',
+    player_team_city_long: 'Dallas',
+    player_points: 15.6
+  },
+  te: {
+    id: 1, 
+    player_name: "Travis Kelce", 
+    teamId: 16, 
+    position: 'te', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/15847.png', 
+    player_team_name_short: 'Chiefs',
+    player_team_name_long: 'Kansas City Chiefs',
+    player_team_city_short: 'KC',
+    player_team_city_long: 'Kansas City',
+    player_points: 14.1
+  },
+  dst: {
+    id: 1,
+    player_name: "NY Giants",
+    teamId: 21,
+    position: 'd/st',
+    player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png",
+    player_team_name_short: 'Giants',
+    player_team_name_long: 'New York Giants',
+    player_team_city_short: 'NYG',
+    player_team_city_long: 'New York',
+    player_points: 12.9
+  },
+  k: {
+    id: 1,
+    player_name: "Justin Tucker",
+    teamId: 3,
+    position: 'k',
+    player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/15683.png", 
+    player_team_name_short: 'Ravens',
+    player_team_name_long: 'Baltimore Ravens',
+    player_team_city_short: 'BAL',
+    player_team_city_long: 'Baltimore',
+    player_points: 11.8
+  }
+}
+
+export const USER2_TEAM : FantasyTeam = {
+  qb: { 
+    id: 1, 
+    player_name: "Patrick Mahomes", 
+    teamId: 4, 
+    position: 'qb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3139477.png', 
+    player_team_name_short: 'Chiefs',
+    player_team_name_long: 'Kansas City Chiefs',
+    player_team_city_short: 'KC',
+    player_team_city_long: 'Kansas City',
+    player_points: 25.2
+  },
+  rb1: {
+    id: 1, 
+    player_name: "David Montgomery", 
+    teamId: 11, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4035538.png', 
+    player_team_name_short: 'Bears',
+    player_team_name_long: 'Chicago Bears',
+    player_team_city_short: 'CHI',
+    player_team_city_long: 'Chicago',
+    player_points: 22.3
+  },
+  rb2: {
+    id: 1, 
+    player_name: "James Cook", 
+    teamId: 4, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
+    player_team_name_short: 'Bills',
+    player_team_name_long: 'Buffalo Bills',
+    player_team_city_short: 'BUF',
+    player_team_city_long: 'Buffalo',
+    player_points: 18.7
+  },
+  wr1: {
+    id: 1, 
+    player_name: "DK Metcalf", 
+    teamId: 28, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4047650.png', 
+    player_team_name_short: 'Seahawks',
+    player_team_name_long: 'Seattle Seahawks',
+    player_team_city_short: 'SEA',
+    player_team_city_long: 'Seattle',
+    player_points: 17.3
+  },
+  wr2: {
+    id: 1, 
+    player_name: "DeVonta Smith", 
+    teamId: 14, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241478.png', 
+    player_team_name_short: 'Eagles',
+    player_team_name_long: 'Philadelphia Eagles',
+    player_team_city_short: 'PHI',
+    player_team_city_long: 'Philadelphia',
+    player_points: 15.6
+  },
+  te: {
+    id: 1, 
+    player_name: "Sam LaPorta", 
+    teamId: 11, 
+    position: 'te', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430027.png', 
+    player_team_name_short: 'Bears',
+    player_team_name_long: 'Chicago Bears',
+    player_team_city_short: 'CHI',
+    player_team_city_long: 'Chicago',
+    player_points: 14.1
+  },
+  dst: {
+    id: 1,
+    player_name: "GB Packers",
+    teamId: 12,
+    position: 'd/st',
+    player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/gb.png",
+    player_team_name_short: 'Packers',
+    player_team_name_long: 'Green Bay Packers',
+    player_team_city_short: 'GB',
+    player_team_city_long: 'Green Bay',
+    player_points: 12.9
+  },
+  k: {
+    id: 1,
+    player_name: "Brandon Aubrey",
+    teamId: 9,
+    position: 'k',
+    player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/3953687.png",
+    player_team_name_short: 'Cowboys',
+    player_team_name_long: 'Dallas Cowboys',
+    player_team_city_short: 'DAL',
+    player_team_city_long: 'Dallas',
+    player_points: 11.8
+  }
+}
+
 export const PLAYER_LIST : NFLPlayerModel[] = [
   {
     id: 1, 
@@ -119,4 +344,11 @@ export const PLAYER_LIST : NFLPlayerModel[] = [
     position: 'k',
     player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/15683.png"
   }, 
+  {
+    id: 1,
+    player_name: "Brandon Aubrey",
+    teamId: 9,
+    position: 'k',
+    player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/3953687.png"
+  }
 ]

--- a/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
+++ b/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
@@ -9,6 +9,7 @@ export type NFLPlayerModel = {
 export type PlayerInfo = {
   id: number;
   player_name: string;
+  player_name_short: string;
   teamId: number;
   position: string;
   player_portrait: string;
@@ -37,6 +38,7 @@ export const USER1_TEAM : FantasyTeam = {
   qb: {
     id: 1, 
     player_name: "Josh Allen", 
+    player_name_short: "J. Allen",
     teamId: 4, 
     position: 'qb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3918298.png', 
@@ -49,6 +51,7 @@ export const USER1_TEAM : FantasyTeam = {
   rb1: {
     id: 1, 
     player_name: "Christian McCaffrey", 
+    player_name_short: "C. McCaffrey",
     teamId: 27, 
     position: 'rb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3117251.png', 
@@ -61,6 +64,7 @@ export const USER1_TEAM : FantasyTeam = {
   rb2: {
     id: 1, 
     player_name: "Kyren Williams", 
+    player_name_short: "K. Williams",
     teamId: 29, 
     position: 'rb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
@@ -73,6 +77,7 @@ export const USER1_TEAM : FantasyTeam = {
   wr1: {
     id: 1, 
     player_name: "Tyreek Hill", 
+    player_name_short: "T. Hill",
     teamId: 17, 
     position: 'wr', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3116406.png', 
@@ -85,6 +90,7 @@ export const USER1_TEAM : FantasyTeam = {
   wr2: {
     id: 1, 
     player_name: "CeeDee Lamb", 
+    player_name_short: "C. Lamb",
     teamId: 9, 
     position: 'wr', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241389.png', 
@@ -97,6 +103,7 @@ export const USER1_TEAM : FantasyTeam = {
   te: {
     id: 1, 
     player_name: "Travis Kelce", 
+    player_name_short: "T. Kelce",
     teamId: 16, 
     position: 'te', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/15847.png', 
@@ -109,8 +116,9 @@ export const USER1_TEAM : FantasyTeam = {
   dst: {
     id: 1,
     player_name: "NY Giants",
+    player_name_short: "Giants",
     teamId: 21,
-    position: 'd/st',
+    position: 'dst',
     player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png",
     player_team_name_short: 'Giants',
     player_team_name_long: 'New York Giants',
@@ -121,6 +129,7 @@ export const USER1_TEAM : FantasyTeam = {
   k: {
     id: 1,
     player_name: "Justin Tucker",
+    player_name_short: "J. Tucker",
     teamId: 3,
     position: 'k',
     player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/15683.png", 
@@ -136,6 +145,7 @@ export const USER2_TEAM : FantasyTeam = {
   qb: { 
     id: 1, 
     player_name: "Patrick Mahomes", 
+    player_name_short: "P. Mahomes", 
     teamId: 4, 
     position: 'qb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3139477.png', 
@@ -148,6 +158,7 @@ export const USER2_TEAM : FantasyTeam = {
   rb1: {
     id: 1, 
     player_name: "David Montgomery", 
+    player_name_short: "D. Montgomery",
     teamId: 11, 
     position: 'rb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4035538.png', 
@@ -160,6 +171,7 @@ export const USER2_TEAM : FantasyTeam = {
   rb2: {
     id: 1, 
     player_name: "James Cook", 
+    player_name_short: "J. Cook",
     teamId: 4, 
     position: 'rb', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
@@ -172,6 +184,7 @@ export const USER2_TEAM : FantasyTeam = {
   wr1: {
     id: 1, 
     player_name: "DK Metcalf", 
+    player_name_short: "D. Metcalf",
     teamId: 28, 
     position: 'wr', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4047650.png', 
@@ -184,6 +197,7 @@ export const USER2_TEAM : FantasyTeam = {
   wr2: {
     id: 1, 
     player_name: "DeVonta Smith", 
+    player_name_short: "D. Smith",
     teamId: 14, 
     position: 'wr', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241478.png', 
@@ -196,6 +210,7 @@ export const USER2_TEAM : FantasyTeam = {
   te: {
     id: 1, 
     player_name: "Sam LaPorta", 
+    player_name_short: "S. LaPorta",
     teamId: 11, 
     position: 'te', 
     player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430027.png', 
@@ -208,8 +223,9 @@ export const USER2_TEAM : FantasyTeam = {
   dst: {
     id: 1,
     player_name: "GB Packers",
+    player_name_short: "Packers",
     teamId: 12,
-    position: 'd/st',
+    position: 'dst',
     player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/gb.png",
     player_team_name_short: 'Packers',
     player_team_name_long: 'Green Bay Packers',
@@ -220,6 +236,7 @@ export const USER2_TEAM : FantasyTeam = {
   k: {
     id: 1,
     player_name: "Brandon Aubrey",
+    player_name_short: "B. Aubrey",
     teamId: 9,
     position: 'k',
     player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/3953687.png",
@@ -327,14 +344,14 @@ export const PLAYER_LIST : NFLPlayerModel[] = [
     id: 1,
     player_name: "NY Giants",
     teamId: 21,
-    position: 'd/st',
+    position: 'dst',
     player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png"
   }, 
   {
     id: 1,
     player_name: "GB Packers",
     teamId: 12,
-    position: 'd/st',
+    position: 'dst',
     player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/gb.png"
   }, 
   {

--- a/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
+++ b/client/app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData.ts
@@ -1,0 +1,122 @@
+export type NFLPlayerModel = {
+  id: number, 
+  player_name: string, 
+  teamId: number, 
+  position: string, 
+  player_portrait: string, 
+}
+
+export const PLAYER_LIST : NFLPlayerModel[] = [
+  {
+    id: 1, 
+    player_name: "Josh Allen", 
+    teamId: 4, 
+    position: 'qb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3918298.png', 
+  },
+  {
+    id: 1, 
+    player_name: "Patrick Mahomes", 
+    teamId: 4, 
+    position: 'qb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3139477.png', 
+  },
+  {
+    id: 1, 
+    player_name: "Christian McCaffrey", 
+    teamId: 27, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3117251.png', 
+  }, 
+  {
+    id: 1, 
+    player_name: "Kyren Williams", 
+    teamId: 29, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
+  },
+  {
+    id: 1, 
+    player_name: "James Cook", 
+    teamId: 4, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430737.png', 
+  },
+  {
+    id: 1, 
+    player_name: "David Montgomery", 
+    teamId: 11, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4035538.png', 
+  },
+  {
+    id: 1, 
+    player_name: "David Montgomery", 
+    teamId: 11, 
+    position: 'rb', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4035538.png', 
+  },
+  {
+    id: 1, 
+    player_name: "Tyreek Hill", 
+    teamId: 17, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/3116406.png', 
+  },
+  {
+    id: 1, 
+    player_name: "CeeDee Lamb", 
+    teamId: 9, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241389.png', 
+  },
+  {
+    id: 1, 
+    player_name: "DK Metcalf", 
+    teamId: 28, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4047650.png', 
+  },
+  {
+    id: 1, 
+    player_name: "DeVonta Smith", 
+    teamId: 14, 
+    position: 'wr', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4241478.png', 
+  },
+  {
+    id: 1, 
+    player_name: "Travis Kelce", 
+    teamId: 16, 
+    position: 'te', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/15847.png', 
+  },
+  {
+    id: 1, 
+    player_name: "Sam LaPorta", 
+    teamId: 11, 
+    position: 'te', 
+    player_portrait: 'https://a.espncdn.com/i/headshots/nfl/players/full/4430027.png', 
+  },
+  {
+    id: 1,
+    player_name: "NY Giants",
+    teamId: 21,
+    position: 'd/st',
+    player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png"
+  }, 
+  {
+    id: 1,
+    player_name: "GB Packers",
+    teamId: 12,
+    position: 'd/st',
+    player_portrait: "https://a.espncdn.com/i/teamlogos/nfl/500/gb.png"
+  }, 
+  {
+    id: 1,
+    player_name: "Justin Tucker",
+    teamId: 3,
+    position: 'k',
+    player_portrait: "https://a.espncdn.com/i/headshots/nfl/players/full/15683.png"
+  }, 
+]

--- a/client/app/navigators/AppNavigator.tsx
+++ b/client/app/navigators/AppNavigator.tsx
@@ -18,6 +18,8 @@ import * as Screens from "app/screens"
 import Config from "../config"
 import { navigate, navigationRef, useBackButtonHandler } from "./navigationUtilities"
 import { colors } from "app/theme"
+import { MatchScorePreviewType } from "../components/MatchScorePreviewTempData/MatchScorePreviewData";
+
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -37,7 +39,7 @@ export type AppStackParamList = {
   Welcome: undefined
   MatchList: undefined
   CreateMatch: undefined
-  MatchDetails: undefined
+  MatchDetails: {currentMatchState: MatchScorePreviewType}
   // 🔥 Your screens go here
   // IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST
 }

--- a/client/app/navigators/AppNavigator.tsx
+++ b/client/app/navigators/AppNavigator.tsx
@@ -37,6 +37,7 @@ export type AppStackParamList = {
   Welcome: undefined
   MatchList: undefined
   CreateMatch: undefined
+  MatchDetails: undefined
   // 🔥 Your screens go here
   // IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST
 }
@@ -82,6 +83,7 @@ const AppStack = observer(function AppStack() {
         <Stack.Screen name="Welcome" component={Screens.WelcomeScreen} />
         <Stack.Screen name="MatchList" component={Screens.MatchListScreen} />
         <Stack.Screen name="CreateMatch" component={Screens.CreateMatchScreen} />
+        <Stack.Screen name="MatchDetails" component={Screens.MatchDetailsScreen} />
           
           
       {/** 🔥 Your screens go here */}

--- a/client/app/screens/DeveloperMenuScreen.tsx
+++ b/client/app/screens/DeveloperMenuScreen.tsx
@@ -70,6 +70,7 @@ export function DeveloperMenuScreen(props: DeveloperMenuScreenProps) {
           variant="solid"
           action="primary"
           marginHorizontal={20}
+          onPress={() => props.navigation.navigate('MatchDetails')}
         >
           <ButtonText fontFamily={typography.fonts.poppins.medium}>Match Details Screen </ButtonText>
           <ButtonIcon as={Swords} />

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -7,6 +7,7 @@ import { MatchScorePreview } from "app/components/MatchScorePreview";
 import { MatchScorePreviewType, MatchScorePreviewData } from "app/components/MatchScorePreviewTempData/MatchScorePreviewData";
 import { LucideChevronLeft } from 'lucide-react-native';
 import { RouteProp } from '@react-navigation/native';
+import { PlayerHeadToHead } from 'app/components/PlayerHeadToHead';
 
 type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
   AppStackParamList,
@@ -97,6 +98,17 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
             matchDetails={currentMatchState} 
             isNavigtionActive={false}
         /> 
+
+        <PlayerHeadToHead 
+          navigation={props.navigation}
+          position="QB"
+          player1="Patrick Mahomes"
+          player2="Tom Brady"
+          player1TeamShort="KC"
+          player2TeamShort="TB"
+          player1Points={25.5}
+          player2Points={20.1}
+        />
 
 
       </View>

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -101,18 +101,12 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
             isNavigtionActive={false}
         /> 
 
-        {/* <PlayerHeadToHead 
-          navigation={props.navigation}
-          position="QB"
-          player1="Patrick Mahomes"
-          player2="Tom Brady"
-          player1TeamShort="KC"
-          player2TeamShort="TB"
-          player1Points={25.5}
-          player2Points={20.1}
-        /> */}
+        <View
+          height={25}
+        >
+        </View>
 
-        {Object.keys(USER1_TEAM).forEach((key) => {
+        {Object.keys(USER1_TEAM).map((key) => {
           let position = key as FantasyTeamKey;
 
           let nflPlayer1: PlayerInfo = USER1_TEAM[position];
@@ -124,6 +118,8 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
               position={nflPlayer1.position}
               player1Name={nflPlayer1.player_name}
               player2Name={nflPlayer2.player_name}
+              player1NameShort={nflPlayer1.player_name_short}
+              player2NameShort={nflPlayer2.player_name_short}          
               player1TeamCityShort={nflPlayer1.player_team_city_short}
               player2TeamCityShort={nflPlayer2.player_team_city_short}
               player1Points={nflPlayer1.player_points}

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react';
+import { Button, ButtonText, ScrollView, FormControl, FormControlLabel, FormControlLabelText, Input, InputField, View, Text, Icon} from "@gluestack-ui/themed";
+import { AppStackParamList } from 'app/navigators/AppNavigator';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { colors, typography} from "app/theme"
+import { MatchScorePreview } from "app/components/MatchScorePreview";
+import { MatchScorePreviewType, MatchScorePreviewData } from "app/components/MatchScorePreviewTempData/MatchScorePreviewData";
+
+type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
+  AppStackParamList,
+  'Welcome'
+>
+
+export interface MatchDetailsScreenProps {
+  navigation: MatchDetailsScreenNavigationProp;
+}
+
+/**
+ * MatchDetailsScreen component allows users to view head-to-head matchups
+ * with individual stats and points of their players for that match.
+ * @component
+ */
+export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
+
+  return (
+    <ScrollView>
+
+      <View
+        backgroundColor={colors.background}
+        flex={1}
+        flexDirection="column"
+        alignItems="center"
+        paddingTop={60}
+        paddingBottom={60}
+        minHeight="100%"
+      
+      >
+
+        <MatchScorePreview matchDetails={MatchScorePreviewData[0]}/> 
+
+
+      </View>
+    </ScrollView>
+  );
+};

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -5,14 +5,23 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { colors, typography} from "app/theme"
 import { MatchScorePreview } from "app/components/MatchScorePreview";
 import { MatchScorePreviewType, MatchScorePreviewData } from "app/components/MatchScorePreviewTempData/MatchScorePreviewData";
+import { LucideChevronLeft } from 'lucide-react-native';
+import { RouteProp } from '@react-navigation/native';
 
 type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
   AppStackParamList,
-  'Welcome'
+  'MatchDetails'
 >
+
+type MatchDetailsScreenRouteProp = RouteProp<
+  AppStackParamList, 
+  'MatchDetails'
+>;
+
 
 export interface MatchDetailsScreenProps {
   navigation: MatchDetailsScreenNavigationProp;
+  route: MatchDetailsScreenRouteProp
 }
 
 /**
@@ -21,6 +30,15 @@ export interface MatchDetailsScreenProps {
  * @component
  */
 export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
+
+  /**
+   * NOTE: An error will be triggered if you enter the match details 
+   * page through the developer menu. This is because the developer menu
+   * doesn't pass in a specific match's information through its navigate 
+   * hook. To make a quick fix for this, I put a default value of an empty
+   * object for this scenario. 
+   */
+  const { currentMatchState = {} } = props.route.params ?? {};
 
   return (
     <ScrollView>
@@ -35,9 +53,43 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
         minHeight="100%"
       
       >
+        <View
+          flexDirection="row"
+          alignItems="center"
+          justifyContent='center'
+          position='relative'  
+          marginTop={30}
+          marginBottom={13}  
+
+        >
+          <Button 
+            onPress={() => props.navigation.navigate('MatchList')} 
+            variant="link" 
+            size="xl" 
+            position='absolute'
+            left={-50}
+          >
+            <Icon 
+              color="$white" 
+              size="xl" 
+              as={LucideChevronLeft} 
+            />
+          </Button>
+
+          <Text
+            color={colors.text}
+            fontSize={32}
+            lineHeight={40}
+            fontFamily={typography.fonts.poppins.bold}
+            textAlign="center"
+          >
+            Match Name
+          </Text>
+        </View>
+
 
         <MatchScorePreview 
-            matchDetails={MatchScorePreviewData[0]} 
+            matchDetails={currentMatchState} 
             isNavigtionActive={false}
         /> 
 

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -13,6 +13,11 @@ type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
   'MatchDetails'
 >
 
+/**
+ * Typing for the 'route' prop, which allows us to access any
+ * parameters/state info that's passed into this screen 
+ * through React Navigation navigate method
+ */
 type MatchDetailsScreenRouteProp = RouteProp<
   AppStackParamList, 
   'MatchDetails'
@@ -35,10 +40,10 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
    * NOTE: An error will be triggered if you enter the match details 
    * page through the developer menu. This is because the developer menu
    * doesn't pass in a specific match's information through its navigate 
-   * hook. To make a quick fix for this, I put a default value of an empty
-   * object for this scenario. 
+   * hook. To make a quick fix for this, I put a default value of the first
+   * sample match in the MatchScorePreviewData array. 
    */
-  const { currentMatchState = {} } = props.route.params ?? {};
+  const { currentMatchState = MatchScorePreviewData[0] } = props.route.params ?? MatchScorePreviewData[0];
 
   return (
     <ScrollView>

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -91,6 +91,7 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
             fontFamily={typography.fonts.poppins.bold}
             textAlign="center"
           >
+            {/** TODO: Change this prop of match name in future  */}
             Match Name
           </Text>
         </View>
@@ -98,36 +99,36 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
 
         <MatchScorePreview 
             matchDetails={currentMatchState} 
-            isNavigtionActive={false}
+            isNavigationActive={false}
         /> 
 
         <View
-          height={25}
+          width={"100%"}
+          marginTop={25}
         >
+          {Object.keys(USER1_TEAM).map((key) => {
+            let position = key as FantasyTeamKey;
+
+            let nflPlayer1: PlayerInfo = USER1_TEAM[position];
+            let nflPlayer2: PlayerInfo = USER2_TEAM[position];
+
+            return (
+              <PlayerHeadToHead
+                navigation={props.navigation}
+                position={nflPlayer1.position}
+                player1Name={nflPlayer1.player_name}
+                player2Name={nflPlayer2.player_name}
+                player1NameShort={nflPlayer1.player_name_short}
+                player2NameShort={nflPlayer2.player_name_short}          
+                player1TeamCityShort={nflPlayer1.player_team_city_short}
+                player2TeamCityShort={nflPlayer2.player_team_city_short}
+                player1Points={nflPlayer1.player_points}
+                player2Points={nflPlayer2.player_points}
+                player1Portrait={nflPlayer1.player_portrait}
+                player2Portrait={nflPlayer2.player_portrait}
+            />)
+          })}
         </View>
-
-        {Object.keys(USER1_TEAM).map((key) => {
-          let position = key as FantasyTeamKey;
-
-          let nflPlayer1: PlayerInfo = USER1_TEAM[position];
-          let nflPlayer2: PlayerInfo = USER2_TEAM[position];
-
-          return (
-            <PlayerHeadToHead
-              navigation={props.navigation}
-              position={nflPlayer1.position}
-              player1Name={nflPlayer1.player_name}
-              player2Name={nflPlayer2.player_name}
-              player1NameShort={nflPlayer1.player_name_short}
-              player2NameShort={nflPlayer2.player_name_short}          
-              player1TeamCityShort={nflPlayer1.player_team_city_short}
-              player2TeamCityShort={nflPlayer2.player_team_city_short}
-              player1Points={nflPlayer1.player_points}
-              player2Points={nflPlayer2.player_points}
-              player1Portrait={nflPlayer1.player_portrait}
-              player2Portrait={nflPlayer2.player_portrait}
-          />)
-        })}
 
       </View>
     </ScrollView>

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -8,6 +8,8 @@ import { MatchScorePreviewType, MatchScorePreviewData } from "app/components/Mat
 import { LucideChevronLeft } from 'lucide-react-native';
 import { RouteProp } from '@react-navigation/native';
 import { PlayerHeadToHead } from 'app/components/PlayerHeadToHead';
+import { USER1_TEAM, USER2_TEAM, PlayerInfo, FantasyTeam, FantasyTeamKey} from 'app/components/PlayerHeadToHeadTempData/PlayerHeadToHeadData';
+
 
 type MatchDetailsScreenNavigationProp = NativeStackNavigationProp<
   AppStackParamList,
@@ -99,7 +101,7 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
             isNavigtionActive={false}
         /> 
 
-        <PlayerHeadToHead 
+        {/* <PlayerHeadToHead 
           navigation={props.navigation}
           position="QB"
           player1="Patrick Mahomes"
@@ -108,8 +110,28 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
           player2TeamShort="TB"
           player1Points={25.5}
           player2Points={20.1}
-        />
+        /> */}
 
+        {Object.keys(USER1_TEAM).forEach((key) => {
+          let position = key as FantasyTeamKey;
+
+          let nflPlayer1: PlayerInfo = USER1_TEAM[position];
+          let nflPlayer2: PlayerInfo = USER2_TEAM[position];
+
+          return (
+            <PlayerHeadToHead
+              navigation={props.navigation}
+              position={nflPlayer1.position}
+              player1Name={nflPlayer1.player_name}
+              player2Name={nflPlayer2.player_name}
+              player1TeamCityShort={nflPlayer1.player_team_city_short}
+              player2TeamCityShort={nflPlayer2.player_team_city_short}
+              player1Points={nflPlayer1.player_points}
+              player2Points={nflPlayer2.player_points}
+              player1Portrait={nflPlayer1.player_portrait}
+              player2Portrait={nflPlayer2.player_portrait}
+          />)
+        })}
 
       </View>
     </ScrollView>

--- a/client/app/screens/MatchDetailsScreen.tsx
+++ b/client/app/screens/MatchDetailsScreen.tsx
@@ -36,7 +36,10 @@ export function MatchDetailsScreen(props: MatchDetailsScreenProps) {
       
       >
 
-        <MatchScorePreview matchDetails={MatchScorePreviewData[0]}/> 
+        <MatchScorePreview 
+            matchDetails={MatchScorePreviewData[0]} 
+            isNavigtionActive={false}
+        /> 
 
 
       </View>

--- a/client/app/screens/MatchListScreen.tsx
+++ b/client/app/screens/MatchListScreen.tsx
@@ -47,7 +47,12 @@ export const MatchListScreen = (props: MatchListProps) => {
           <PaginateWeek weeks={weeks} onWeekChange={handleWeekChange} />
           {/* Map through each match that is part of the current week. */}
           {currentWeekData.map((data, index) => (
-            <MatchScorePreview key={index} matchDetails={data} navigation={props.navigation} isNavigtionActive={true} />
+            <MatchScorePreview 
+              key={index} 
+              matchDetails={data} 
+              navigation={props.navigation} 
+              isNavigtionActive={true} 
+            />
           ))}
         </View>
       </ScrollView>

--- a/client/app/screens/MatchListScreen.tsx
+++ b/client/app/screens/MatchListScreen.tsx
@@ -77,7 +77,8 @@ export const MatchListScreen = (props: MatchListProps) => {
 
 // Styling
 const $mainContainer: ViewStyle = {
-  backgroundColor: "#292929", 
+  // backgroundColor: "#292929", 
+  backgroundColor: colors.background,
   flex: 1, 
   flexDirection: "column",
   gap: 10,

--- a/client/app/screens/MatchListScreen.tsx
+++ b/client/app/screens/MatchListScreen.tsx
@@ -51,7 +51,7 @@ export const MatchListScreen = (props: MatchListProps) => {
               key={index} 
               matchDetails={data} 
               navigation={props.navigation} 
-              isNavigtionActive={true} 
+              isNavigationActive={true} 
             />
           ))}
         </View>

--- a/client/app/screens/MatchListScreen.tsx
+++ b/client/app/screens/MatchListScreen.tsx
@@ -47,7 +47,7 @@ export const MatchListScreen = (props: MatchListProps) => {
           <PaginateWeek weeks={weeks} onWeekChange={handleWeekChange} />
           {/* Map through each match that is part of the current week. */}
           {currentWeekData.map((data, index) => (
-            <MatchScorePreview key={index} matchDetails={data} />
+            <MatchScorePreview key={index} matchDetails={data} navigation={props.navigation} isNavigtionActive={true} />
           ))}
         </View>
       </ScrollView>

--- a/client/app/screens/index.ts
+++ b/client/app/screens/index.ts
@@ -4,4 +4,6 @@ export * from "./ErrorScreen/ErrorBoundary"
 export * from "./MatchListScreen"
 export * from "./DeveloperMenuScreen"
 export * from "./CreateMatchScreen"
+export * from "./MatchDetailsScreen"
+
 

--- a/client/app/theme/colors.ts
+++ b/client/app/theme/colors.ts
@@ -15,6 +15,13 @@ const palette: Record<string, string> = {
   angry100: "#F2D6CD",
   angry500: "#C03403",
 
+  primary100: "#FFC107",
+  primary200: "#4CAF50", 
+  primary300: "#2196F3", 
+  primary400: "#9C27B0", 
+  primary500: "#FF9800", 
+  primary600: "#F44336"
+
 
 } as const
 
@@ -70,4 +77,29 @@ export const colors = {
    *
    */
   errorBackground: palette.angry100,
+
+  /**
+   * Color for quarterback backgrounds
+   */
+  qbBackground: palette.primary100,
+  /**
+   * Color for runningback backgrounds
+   */
+  rbBackground: palette.primary200,
+  /**
+   * Color for wide receiver backgrounds
+   */
+  wrBackground: palette.primary300,
+  /**
+   * Color for tight end backgrounds
+   */
+  teBackground: palette.primary400,
+  /**
+   * Color for kicker backgrounds
+   */
+  kBackground: palette.primary500,
+  /**
+   * Color for defense/special teams backgrounds
+   */
+  dstBackground: palette.primary600,
 }

--- a/client/app/theme/colors.ts
+++ b/client/app/theme/colors.ts
@@ -36,6 +36,10 @@ export const colors = {
    */
   textDim: palette.neutral400,
   /**
+   * Dark text color.
+   */
+  textBlack: palette.neutral900,
+  /**
    * The secondary color of the screen background.
    */
   secondaryBackground: palette.neutral500,

--- a/client/app/theme/colors.ts
+++ b/client/app/theme/colors.ts
@@ -6,7 +6,9 @@ const palette: Record<string, string> = {
   neutral100: "#FFFFFF",
   neutral300: "#D7CEC9",
   neutral400: "#9E9E9E",
-  neutral500: "#292929",
+  // neutral500: "#292929",
+  // neutral500: "#424242",
+  neutral500: "#303030",
   neutral600: "#1D1D1D", 
   neutral900: "#000000",
 


### PR DESCRIPTION
Created a new screen that will hold the head-to-head matchup between two users

#27 

- Imported the previous match preview component to use as the header for this screen
- Created a new head-to-head component that displays specific player info and points. 
- Used a flex-box row to order the player info, scores, and positions (The CSS on this was kind of painful). 
- Created mock data in `PlayerHeadToHeadData.ts` to use for now in the code (Note: this file contains all info about players, such as points, name, team, etc. In the future, we might have to edit the code a little bit based on how we configure our UX calls upon the API. I.e., what info we receive from the data from the API)
- Added position-specific colors to the colors file. Note: I used more muted colors than the ones found in the Figma. 

TODO: 
- In the future, we should add another field to the NFLPlayer model called player_name_short. This will be used in our details screen. 
- I feel like the spacing between the player name and the player team (in the head-to-head component) is a little too much. Do you know how we might be able to fix this? 

<img width="400" alt="Screenshot 2024-01-20 at 7 02 30 PM" src="https://github.com/jbrw1984/stinkball/assets/115956825/3cffbd4e-ac11-4df1-b51c-50065edd21cb">